### PR TITLE
Removed dependency on modified pvclust, synchronized .md and Rmd version

### DIFF
--- a/ILC_scRNA_analysis.Rmd
+++ b/ILC_scRNA_analysis.Rmd
@@ -13,7 +13,7 @@ Written by Åsa K. Björklund, 2015, asa.bjorklund@scilifelab.se
 ## Dependencies
 
 #### Cran packages:
-statmod, gplots, plotrix, Rtsne, MASS, vioplot 
+statmod, gplots, plotrix, Rtsne, MASS, vioplot, pvclust
 
 #### Bioconductor:
 sva
@@ -157,12 +157,10 @@ plot(RES[[1]]$Y,col=col.cell,pch=pch.ton,ylab='',xlab='')
 ```
 
 ## Bootstrapped clustering with pvclust
-pvclust based on euclidean distances instead of correlations are done using modified pvclust package from:
-http://www.is.titech.ac.jp/~shimo/prog/pvclust/pvclust_unofficial_090824.zip
+pvclust based on euclidean distances instead of correlations are done 
 ```{r message=FALSE, warning=FALSE}
 # set to whaterver path you have for the pvclust package:
-source("/Users/asab/jobb/data/local/bin/pvclust_unofficial_090824/pvclust.R")
-source("/Users/asab/jobb/data/local/bin/pvclust_unofficial_090824/pvclust-internal.R")
+library(pvclust)
 library(MASS)
 
 Rsum<-Reduce("cbind",lapply(RES,function(x) x$Y))

--- a/ILC_scRNA_analysis.md
+++ b/ILC_scRNA_analysis.md
@@ -15,7 +15,7 @@ Dependencies
 
 #### Cran packages:
 
-statmod, gplots, plotrix, Rtsne, MASS, vioplot
+statmod, gplots, plotrix, Rtsne, MASS, vioplot, pvclust
 
 #### Bioconductor:
 
@@ -155,7 +155,7 @@ are slightly differen each time. The results are stored in a list RES.
     savefile1 <- "data/tsne_10Pc_20i.Rdata"
     force.tsne<-FALSE
     if (!file.exists(savefile1) || force.tsne){
-      C<-cb0[var.genes[,2],]
+      C<-cb0[var.genes,]
       RES<-list()
       pdf("figures/tsne_10PC_20i.pdf")
       par(mfrow=c(4,4),mar=c(1,1,3,1))
@@ -178,12 +178,8 @@ Bootstrapped clustering with pvclust
 ------------------------------------
 
 pvclust based on euclidean distances instead of correlations are done
-using modified pvclust package from:
-<http://www.is.titech.ac.jp/~shimo/prog/pvclust/pvclust_unofficial_090824.zip>
 
-    # set to whaterver path you have for the pvclust package:
-    source("/Users/asab/jobb/data/local/bin/pvclust_unofficial_090824/pvclust.R")
-    source("/Users/asab/jobb/data/local/bin/pvclust_unofficial_090824/pvclust-internal.R")
+    library(pvclust)
     library(MASS)
 
     Rsum<-Reduce("cbind",lapply(RES,function(x) x$Y))


### PR DESCRIPTION
I noticed that the modified pvclust mentiond in the scRNAseq workflow is no longer available, but that euclidean distance is supported by the current pvclust out of the box, so I fixed that. Also the bug fixed in https://github.com/asabjorklund/ILC_scRNAseq/commit/4cb5318490684dd439eef9307e162675ba2dd8ff propagated only to the .Rmd version and not the .md version of the workflow (which is linked from Readme.md) so I synchronized both of the versions as I do not know, which is the preferred one.